### PR TITLE
Add Sodium & Mod Menu support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,9 @@ dependencies {
     include "com.github.Fallen-Breath:conditional-mixin:${project.conditional_mixins_version}"
 
     // Sodium Compatibility
-    modImplementation "maven.modrinth:sodium:${project.sodium_version}"
+    modCompileOnly "maven.modrinth:sodium:${project.sodium_version}"
+
+    modCompileOnly "maven.modrinth:modmenu:${project.modmenu_version}"
 }
 
 processResources {

--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ dependencies {
     include "com.github.Fallen-Breath:conditional-mixin:${project.conditional_mixins_version}"
 
     // Sodium Compatibility
-    modImplementation "maven.modrinth:sodium:${project.sodium_version}"
+    modCompileOnly "maven.modrinth:sodium:${project.sodium_version}"
 }
 
 processResources {

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,23 @@ repositories {
     // Loom adds the essential maven repositories to download Minecraft and libraries from automatically.
     // See https://docs.gradle.org/current/userguide/declaring_repositories.html
     // for more information about repositories.
+    allprojects {
+        repositories {
+            maven { url 'https://jitpack.io' }
+        }
+    }
+
+    exclusiveContent {
+        forRepository {
+            maven {
+                name = "Modrinth"
+                url = "https://api.modrinth.com/maven"
+            }
+        }
+        filter {
+            includeGroup "maven.modrinth"
+        }
+    }
 }
 
 dependencies {
@@ -19,6 +36,12 @@ dependencies {
     minecraft "com.mojang:minecraft:${project.minecraft_version}"
     mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
     modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
+
+    modImplementation "com.github.Fallen-Breath:conditional-mixin:${project.conditional_mixins_version}"
+    include "com.github.Fallen-Breath:conditional-mixin:${project.conditional_mixins_version}"
+
+    // Sodium Compatibility
+    modImplementation "maven.modrinth:sodium:${project.sodium_version}"
 }
 
 processResources {

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,9 @@ dependencies {
 
     // Sodium Compatibility
     modCompileOnly "maven.modrinth:sodium:${project.sodium_version}"
+
+    modCompileOnly "maven.modrinth:modmenu:${project.modmenu_version}"
+
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,9 +3,9 @@ org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
 
-minecraft_version=1.20.1
-yarn_mappings=1.20.1+build.8
-loader_version=0.14.21
+minecraft_version=1.20.2
+yarn_mappings=1.20.2+build.4
+loader_version=0.14.24
 
 # Mod Properties
 mod_version=1.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,8 +3,8 @@ org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
 
-minecraft_version=1.20.2
-yarn_mappings=1.20.2+build.4
+minecraft_version=1.20.1
+yarn_mappings=1.20.1+build.10
 loader_version=0.14.24
 
 # Mod Properties
@@ -15,3 +15,6 @@ archives_base_name=particle-blocker
 sodium_version=mc1.20.2-0.5.3
 
 conditional_mixins_version=v0.4.1
+
+modmenu_version=7.2.1
+

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,4 +14,6 @@ archives_base_name=particle-blocker
 
 sodium_version=mc1.20.2-0.5.3
 
+modmenu_version=7.2.1
+
 conditional_mixins_version=v0.4.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,3 +12,6 @@ mod_version=1.1
 maven_group=me.declipsonator
 archives_base_name=particle-blocker
 
+sodium_version=mc1.20.2-0.5.3
+
+conditional_mixins_version=v0.4.1

--- a/src/main/java/me/declipsonator/particleblocker/MixinConfigPlugin.java
+++ b/src/main/java/me/declipsonator/particleblocker/MixinConfigPlugin.java
@@ -1,0 +1,23 @@
+package me.declipsonator.particleblocker;
+
+import me.fallenbreath.conditionalmixin.api.mixin.RestrictiveMixinConfigPlugin;
+
+import java.util.List;
+import java.util.Set;
+
+public class MixinConfigPlugin extends RestrictiveMixinConfigPlugin {
+    @Override
+    public String getRefMapperConfig() {
+        return null;
+    }
+
+    @Override
+    public void acceptTargets(Set<String> myTargets, Set<String> otherTargets) {
+
+    }
+
+    @Override
+    public List<String> getMixins() {
+        return null;
+    }
+}

--- a/src/main/java/me/declipsonator/particleblocker/ParticleBlocker.java
+++ b/src/main/java/me/declipsonator/particleblocker/ParticleBlocker.java
@@ -1,6 +1,7 @@
 package me.declipsonator.particleblocker;
 
 import net.fabricmc.api.ModInitializer;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.client.option.SimpleOption;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/src/main/java/me/declipsonator/particleblocker/mixins/sodium/SodiumGameOptionPagesMixin.java
+++ b/src/main/java/me/declipsonator/particleblocker/mixins/sodium/SodiumGameOptionPagesMixin.java
@@ -46,11 +46,21 @@ public abstract class SodiumGameOptionPagesMixin extends Screen {
             return;
         }
 
+        String text1 = "Particles Menu Requires that Reeses Sodium Options be installed.";
+
         drawContext.drawCenteredTextWithShadow(
                 textRenderer,
-                Text.of("Particles Menu Requires that Reeses Sodium Options be installed."),
+                Text.of(text1),
                 drawContext.getScaledWindowWidth() / 2,
                 drawContext.getScaledWindowHeight() / 2,
+                0xFFFFFF
+        );
+
+        drawContext.drawCenteredTextWithShadow(
+                textRenderer,
+                Text.of("A Second Menu is present in accessibility settings or ModMenu config"),
+                drawContext.getScaledWindowWidth() / 2,
+                drawContext.getScaledWindowHeight() / 2 + textRenderer.getWrappedLinesHeight(text1, Integer.MAX_VALUE) + 3,
                 0xFFFFFF
         );
     }

--- a/src/main/java/me/declipsonator/particleblocker/mixins/sodium/SodiumGameOptionPagesMixin.java
+++ b/src/main/java/me/declipsonator/particleblocker/mixins/sodium/SodiumGameOptionPagesMixin.java
@@ -1,0 +1,57 @@
+package me.declipsonator.particleblocker.mixins.sodium;
+
+import com.google.common.collect.ImmutableList;
+import me.declipsonator.particleblocker.MixinConfigPlugin;
+import me.declipsonator.particleblocker.sodium.ParticlesSodiumPage;
+import me.fallenbreath.conditionalmixin.api.annotation.Condition;
+import me.fallenbreath.conditionalmixin.api.annotation.Restriction;
+import me.jellysquid.mods.sodium.client.gui.SodiumGameOptionPages;
+import me.jellysquid.mods.sodium.client.gui.SodiumOptionsGUI;
+import me.jellysquid.mods.sodium.client.gui.options.OptionPage;
+import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.widget.TextWidget;
+import net.minecraft.text.Text;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.List;
+
+@Restriction(require = @Condition("sodium"))
+@Mixin(SodiumOptionsGUI.class)
+public abstract class SodiumGameOptionPagesMixin extends Screen {
+    @Shadow @Final private List<OptionPage> pages;
+
+    @Shadow private OptionPage currentPage;
+
+    protected SodiumGameOptionPagesMixin() {
+        super(Text.translatable("Sodium Options"));
+    }
+
+
+    @Inject(method = "<init>", at = @At(value = "RETURN"))
+    void init(CallbackInfo ci) {
+        this.pages.add(ParticlesSodiumPage.createPage());
+    }
+
+    @Inject(method = "render", at = @At(value = "RETURN"))
+    void addReesesSodiumOptionsRequiredText(DrawContext drawContext, int mouseX, int mouseY, float delta, CallbackInfo ci) {
+        if(FabricLoader.getInstance().isModLoaded("reeses-sodium-options") || !this.currentPage.getName().getString().equals("Particles")) {
+            return;
+        }
+
+        drawContext.drawCenteredTextWithShadow(
+                textRenderer,
+                Text.of("Particles Menu Requires that Reeses Sodium Options be installed."),
+                drawContext.getScaledWindowWidth() / 2,
+                drawContext.getScaledWindowHeight() / 2,
+                0xFFFFFF
+        );
+    }
+}

--- a/src/main/java/me/declipsonator/particleblocker/modmenu/ModMenuConfig.java
+++ b/src/main/java/me/declipsonator/particleblocker/modmenu/ModMenuConfig.java
@@ -1,0 +1,13 @@
+package me.declipsonator.particleblocker.modmenu;
+
+import com.terraformersmc.modmenu.api.ConfigScreenFactory;
+import com.terraformersmc.modmenu.api.ModMenuApi;
+import me.declipsonator.particleblocker.screen.ParticlesScreen;
+import net.minecraft.client.MinecraftClient;
+
+public class ModMenuConfig implements ModMenuApi {
+    @Override
+    public ConfigScreenFactory<?> getModConfigScreenFactory() {
+        return (screen) -> new ParticlesScreen(screen, MinecraftClient.getInstance().options);
+    }
+}

--- a/src/main/java/me/declipsonator/particleblocker/screen/ParticlesScreen.java
+++ b/src/main/java/me/declipsonator/particleblocker/screen/ParticlesScreen.java
@@ -50,8 +50,7 @@ public class ParticlesScreen extends GameOptionsScreen {
 
     @Override
     public void render(DrawContext context, int mouseX, int mouseY, float delta) {
-        this.renderBackgroundTexture(context);
-        super.render(context, mouseX, mouseY, delta);
+        this.renderBackground(context);
         particleWidget.render(context, mouseX, mouseY, delta);
         context.drawCenteredTextWithShadow(textRenderer, title, width / 2, 8, 16777215);
         boolean allTrue = true;
@@ -69,6 +68,7 @@ public class ParticlesScreen extends GameOptionsScreen {
         if(allOn) changeAllButton.setMessage(Text.of("Toggle All Off").copy().formatted(Formatting.RED));
         else changeAllButton.setMessage(Text.of("Toggle All On").copy().formatted(Formatting.GREEN));
 
+        super.render(context, mouseX, mouseY, delta);
     }
 
     @Override

--- a/src/main/java/me/declipsonator/particleblocker/screen/ParticlesScreen.java
+++ b/src/main/java/me/declipsonator/particleblocker/screen/ParticlesScreen.java
@@ -50,7 +50,8 @@ public class ParticlesScreen extends GameOptionsScreen {
 
     @Override
     public void render(DrawContext context, int mouseX, int mouseY, float delta) {
-        this.renderBackground(context);
+        this.renderBackgroundTexture(context);
+        super.render(context, mouseX, mouseY, delta);
         particleWidget.render(context, mouseX, mouseY, delta);
         context.drawCenteredTextWithShadow(textRenderer, title, width / 2, 8, 16777215);
         boolean allTrue = true;
@@ -68,7 +69,6 @@ public class ParticlesScreen extends GameOptionsScreen {
         if(allOn) changeAllButton.setMessage(Text.of("Toggle All Off").copy().formatted(Formatting.RED));
         else changeAllButton.setMessage(Text.of("Toggle All On").copy().formatted(Formatting.GREEN));
 
-        super.render(context, mouseX, mouseY, delta);
     }
 
     @Override

--- a/src/main/java/me/declipsonator/particleblocker/sodium/EmptyOptionStorage.java
+++ b/src/main/java/me/declipsonator/particleblocker/sodium/EmptyOptionStorage.java
@@ -1,0 +1,17 @@
+package me.declipsonator.particleblocker.sodium;
+
+import me.declipsonator.particleblocker.Config;
+import me.jellysquid.mods.sodium.client.gui.options.storage.OptionStorage;
+
+public class EmptyOptionStorage implements OptionStorage<Object> {
+
+    @Override
+    public Object getData() {
+        return new Object();
+    }
+
+    @Override
+    public void save() {
+
+    }
+}

--- a/src/main/java/me/declipsonator/particleblocker/sodium/ParticlesSodiumPage.java
+++ b/src/main/java/me/declipsonator/particleblocker/sodium/ParticlesSodiumPage.java
@@ -54,7 +54,7 @@ public class ParticlesSodiumPage {
                 .setName(pair.title)
                 .setControl(TickBoxControl::new)
                 .setImpact(OptionImpact.LOW)
-                .setTooltip(Text.of("Disables rendering of " + pair.title.getString()))
+                .setTooltip(Text.of("Toggles rendering of the " + pair.title.getString() + " particle."))
                 .setBinding((opts, value) -> Config.changeValue(pair.idParticle.toString()), (opts) -> Config.getValue(pair.idParticle.toString()))
             .build();
     }

--- a/src/main/java/me/declipsonator/particleblocker/sodium/ParticlesSodiumPage.java
+++ b/src/main/java/me/declipsonator/particleblocker/sodium/ParticlesSodiumPage.java
@@ -1,0 +1,66 @@
+package me.declipsonator.particleblocker.sodium;
+
+import com.google.common.collect.ImmutableList;
+import me.declipsonator.particleblocker.Config;
+import me.declipsonator.particleblocker.screen.ParticlesWidget;
+import me.declipsonator.particleblocker.utils.idComparator;
+import me.jellysquid.mods.sodium.client.gui.options.*;
+import me.jellysquid.mods.sodium.client.gui.options.control.TickBoxControl;
+import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.registry.Registries;
+import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ParticlesSodiumPage {
+    static EmptyOptionStorage emptyOptionStorage = new EmptyOptionStorage();
+
+    public static OptionPage createPage() {
+        List<OptionGroup> groups = new ArrayList<>();
+
+        if(!FabricLoader.getInstance().isModLoaded("reeses-sodium-options")) {
+            return new OptionPage(Text.of("Particles"), ImmutableList.copyOf(groups));
+        }
+
+        var builder = OptionGroup.createBuilder();
+
+        ArrayList<Identifier> particles = new ArrayList<>(Registries.PARTICLE_TYPE.getIds());
+        particles.sort(new idComparator());
+
+        ArrayList<ParticlePair> pairs = new ArrayList<>();
+
+        for (Identifier idParticle : particles) {
+            pairs.add(new ParticlePair(idParticle, Text.of(Arrays.stream(idParticle.getPath().split("_")).map(StringUtils::capitalize).collect(Collectors.joining(" ")))));
+        }
+
+        for(var pair : pairs) {
+            builder.add(makeSodiumOptionFromParticlePair(pair));
+        }
+
+        groups.add(builder.build());
+
+        return new OptionPage(Text.of("Particles"), ImmutableList.copyOf(groups));
+    }
+
+
+    private static Option<Boolean> makeSodiumOptionFromParticlePair(ParticlePair pair) {
+        return OptionImpl.createBuilder(boolean.class, emptyOptionStorage)
+                .setName(pair.title)
+                .setControl(TickBoxControl::new)
+                .setImpact(OptionImpact.LOW)
+                .setTooltip(Text.of("Disables rendering of " + pair.title.getString()))
+                .setBinding((opts, value) -> Config.changeValue(pair.idParticle.toString()), (opts) -> Config.getValue(pair.idParticle.toString()))
+            .build();
+    }
+
+
+    record ParticlePair(Identifier idParticle, Text title) {
+
+    }
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -12,6 +12,9 @@
   "entrypoints": {
     "main": [
       "me.declipsonator.particleblocker.ParticleBlocker"
+    ],
+    "modmenu": [
+      "me.declipsonator.particleblocker.modmenu.ModMenuConfig"
     ]
   },
   "mixins": [

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -21,7 +21,7 @@
     "particle-blocker.mixins.json"
   ],
   "depends": {
-    "minecraft": ">=1.20.1"
+    "minecraft": ">=1.20.2"
   },
   "custom": {
     "sodium-extra:options": {

--- a/src/main/resources/particle-blocker.mixins.json
+++ b/src/main/resources/particle-blocker.mixins.json
@@ -4,12 +4,14 @@
   "package": "me.declipsonator.particleblocker.mixins",
   "compatibilityLevel": "JAVA_16",
   "client": [
-    "ParticleManagerMixin",
     "AccessibilityOptionsScreenMixin",
-    "VideoOptionsScreenMixin",
+    "FireworkParticleMixin",
+    "ParticleManagerMixin",
     "SimpleOptionsMixin",
-    "FireworkParticleMixin"
+    "VideoOptionsScreenMixin",
+    "sodium.SodiumGameOptionPagesMixin"
   ],
+  "plugin": "me.declipsonator.particleblocker.MixinConfigPlugin",
   "injectors": {
     "defaultRequire": 1
   }


### PR DESCRIPTION
This resolves issue #9's request. 

**This is in 1.20.1 My other PR is for 1.20.2**

The mod now optionally uses sodium, but the menu will only render if Reeses Sodium Options is installed. Otherwise it will show a message on the added page that "Particles Menu Requires that Reeses Sodium Options be installed."

![image](https://github.com/Declipsonator/Particle-Blocker/assets/52091447/1eed73a1-8c96-4190-a8c8-038067d3957a)

The mod also now optionally uses Mod menu.